### PR TITLE
Use staticcall since we do not modify state

### DIFF
--- a/src/ReadALot.sol
+++ b/src/ReadALot.sol
@@ -18,7 +18,7 @@ contract ReadALot {
                 let _retLen     := mul(mload(add(data, add(cur, 0x20))), 0x20)
                 let _dataLength := mload(add(data, add(cur, 0x60)))
                 let _data       := add(data, add(cur, 0x80))
-                if eq(call(gas, _target, 0, _data, _dataLength, ptr, _retLen), 0) 
+                if eq(staticcall(gas, _target, _data, _dataLength, ptr, _retLen), 0) 
                     { revert(0, 0) }
                 let _retVal := mload(ptr)
                 mstore(add(tempBytes, mul(inc, 0x20)), _retVal)


### PR DESCRIPTION
This is an amazing idea! I've been playing with it a bit.

This PR changes `call` into `staticcall` since the idea is to not modify state.